### PR TITLE
fix(console): remove trailing semicolons from macro expansions

### DIFF
--- a/crates/console/src/console_dbg.rs
+++ b/crates/console/src/console_dbg.rs
@@ -9,7 +9,7 @@ macro_rules! console {
         $crate::log!(
             ::std::format!("%c[{}:{}] ", ::std::file!(), ::std::line!()),
             "font-weight: bold"
-        );
+        )
     };
     ($val:expr $(,)?) => {
         {

--- a/crates/console/src/macros.rs
+++ b/crates/console/src/macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 macro_rules! clear {
     () => {
-        $crate::externs::clear();
+        $crate::externs::clear()
     };
 }
 
@@ -10,7 +10,7 @@ macro_rules! clear {
 #[macro_export]
 macro_rules! assert {
     ($assertion:expr, $($arg:expr),+) => {
-       $crate::externs::assert($assertion, ::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::assert($assertion, ::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -18,7 +18,7 @@ macro_rules! assert {
 #[macro_export]
 macro_rules! debug {
     ($($arg:expr),+) => {
-       $crate::externs::debug(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::debug(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -32,7 +32,7 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! dir {
     ($arg:expr) => {
-        $crate::externs::dir(&$crate::__macro::JsValue::from($arg));
+        $crate::externs::dir(&$crate::__macro::JsValue::from($arg))
     };
 }
 
@@ -46,7 +46,7 @@ macro_rules! dir {
 #[macro_export]
 macro_rules! dirxml {
     ($arg:expr) => {
-        $crate::externs::dirxml(&$crate::__macro::JsValue::from($arg));
+        $crate::externs::dirxml(&$crate::__macro::JsValue::from($arg))
     };
 }
 
@@ -54,7 +54,7 @@ macro_rules! dirxml {
 #[macro_export]
 macro_rules! error {
     ($($arg:expr),+) => {
-       $crate::externs::error(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::error(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -64,10 +64,10 @@ macro_rules! error {
 #[macro_export]
 macro_rules! group {
     ($($arg:expr),+) => {
-       $crate::externs::group(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::group(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     };
     (collapsed $($arg:expr),+) => {
-       $crate::externs::group_collapsed(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::group_collapsed(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     };
 }
 
@@ -75,7 +75,7 @@ macro_rules! group {
 #[macro_export]
 macro_rules! group_end {
     () => {
-        $crate::externs::group_end();
+        $crate::externs::group_end()
     };
 }
 
@@ -83,7 +83,7 @@ macro_rules! group_end {
 #[macro_export]
 macro_rules! info {
     ($($arg:expr),+) => {
-       $crate::externs::info(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::info(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -97,10 +97,10 @@ macro_rules! info {
 #[macro_export]
 macro_rules! table {
     ($data:expr) => {
-        $crate::externs::table_with_data($crate::__macro::JsValue::from($data));
+        $crate::externs::table_with_data($crate::__macro::JsValue::from($data))
     };
     ($data:expr, $columns:expr) => {
-        $crate::__macro::table_with_data_and_columns($data, $columns);
+        $crate::__macro::table_with_data_and_columns($data, $columns)
     };
 }
 
@@ -108,7 +108,7 @@ macro_rules! table {
 #[macro_export]
 macro_rules! log {
     ($($arg:expr),+) => {
-       $crate::externs::log(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::log(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -116,7 +116,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! trace {
     ($($arg:expr),+) => {
-       $crate::externs::trace(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::trace(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
     }
 }
 
@@ -124,6 +124,31 @@ macro_rules! trace {
 #[macro_export]
 macro_rules! warn {
     ($($arg:expr),+) => {
-       $crate::externs::warn(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]));
+       $crate::externs::warn(::std::boxed::Box::from([$($crate::__macro::JsValue::from($arg),)+]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(dead_code)]
+    //! These exist to ensure macros compile in expression position
+    //! (no trailing semicolon in the expansion, see rust-lang/rust#79813)
+
+    fn expression_position_works() {
+        let _: () = crate::clear!();
+        let _: () = crate::assert!(true, "msg");
+        let _: () = crate::debug!("debug");
+        let _: () = crate::dir!("dir");
+        let _: () = crate::dirxml!("dirxml");
+        let _: () = crate::error!("error");
+        let _: () = crate::group!("group");
+        let _: () = crate::group!(collapsed "group");
+        let _: () = crate::group_end!();
+        let _: () = crate::info!("info");
+        let _: () = crate::table!(crate::__macro::JsValue::from("data"));
+        let _: () = crate::log!("log");
+        let _: () = crate::trace!("trace");
+        let _: () = crate::warn!("warn");
+        let _: () = crate::console!();
     }
 }

--- a/crates/history/src/state.rs
+++ b/crates/history/src/state.rs
@@ -51,13 +51,9 @@ pub(crate) fn extract_state(raw: JsValue) -> (Option<u32>, Option<JsValue>) {
     let id = Some(history_state.id());
 
     let key = JsValue::from_str("state");
-    let user_state = js_sys::Reflect::get(&raw, &key).ok().and_then(|v| {
-        if v.is_undefined() || v.is_null() {
-            None
-        } else {
-            Some(v)
-        }
-    });
+    let user_state = js_sys::Reflect::get(&raw, &key)
+        .ok()
+        .filter(|v| !(v.is_undefined() || v.is_null()));
 
     (id, user_state)
 }


### PR DESCRIPTION
This fixes the nightly CI breakage in the Native, Browser, Node and gloo-net test jobs.

The gloo-console macros (`log!`, `error!`, `dir!`, etc.) all expanded to a statement with a trailing semicolon. When such a macro is invoked in expression position (e.g. as the final expression of a block, as in the gloo-console and gloo-net crate-level doc examples), this triggers the `semicolon_in_expressions_from_macros` future-incompatibility lint (rust-lang/rust#79813). rust-lang/rust#159222 recently extended the lint to non-local macros at deny level, which broke the nightly doctest jobs; rust-lang/rust#159700 has since split the non-local case into a warn-level lint, but the plan remains to make this a hard error (rust-lang/rust#159218), and the lint is already deny-by-default for local macro uses on stable.

* Removes the trailing semicolon from every gloo-console macro expansion so they are valid in both statement and expression position (all expansions evaluate to `()`)
* Adds compile-only tests exercising each macro in expression position, which fail at deny level before this change
* Fixes a pre-existing `clippy::manual_filter` error in gloo-history that newer clippy flags, which was failing the Lint & Format job

_Made with AI assistance under my review_